### PR TITLE
Make proxy protocol available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ go:
   - 1.10.2
 cache:
   directories:
-    misc/test/data
+    - misc/test/data
+    - vendor
+    - /go/src/github.com
 notifications:
   slack: pepabo:urThJPQ6Vh8m3cI7riDpYAbn

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,6 +50,14 @@
   revision = "60e520f5feed5eaa0951aeecfc772a35bbe9f83d"
 
 [[projects]]
+  branch = "master"
+  digest = "1:57e13d10425e24333e3c6df6915fd5dd54aaa533a4a3e336208c2b4cb8405b6d"
+  name = "github.com/pires/go-proxyproto"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2f38359974ffed92842a86ffcc17001b3f525e34"
+
+[[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -101,6 +109,7 @@
     "github.com/jlaffaye/ftp",
     "github.com/julienschmidt/httprouter",
     "github.com/marcobeierer/ftps",
+    "github.com/pires/go-proxyproto",
     "github.com/sirupsen/logrus",
     "golang.org/x/sync/errgroup",
   ]

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ ftp-cleanup: vsftpd-cleanup proftpd-cleanup
 
 integration:
 	@echo "$(INFO_COLOR)==> $(RESET)$(BOLD)Integration Testing$(RESET)"
+	./misc/server stop || true
 	./misc/server start
 	go test $(VERBOSE) -integration $(TEST) $(TEST_OPTIONS)
 	./misc/server stop

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ max_connections = 10
 idle_timeout = 60
 transfer_timeout = 600
 remote_addr = "127.0.0.1:21"
+proxy_protocol = false
 
 [tls]
 cert = "./tls/server.crt"

--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -233,7 +233,7 @@ func (c *clientHandler) handleCommand(line string) (r *result) {
 
 func (c *clientHandler) connectControlProxy() error {
 	if c.controleProxy != nil {
-		err := c.controleProxy.SwitchOrigin(c.context.RemoteAddr)
+		err := c.controleProxy.SwitchOrigin(c.conn.RemoteAddr().String(), c.context.RemoteAddr, c.config.ProxyProtocol)
 		if err != nil {
 			return err
 		}

--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -103,7 +103,6 @@ func (c *clientHandler) HandleCommands() error {
 					c.controleProxy.CloseOk = false
 				} else {
 					proxyError <- err
-
 				}
 				break
 			}
@@ -212,7 +211,13 @@ func (c *clientHandler) handleCommand(line string) (r *result) {
 	cmd := handlers[c.command]
 	if cmd != nil {
 		if cmd.suspend {
-			c.controleProxy.Suspend()
+			err := c.controleProxy.Suspend()
+			if err != nil {
+				return &result{
+					code: 500,
+					msg:  fmt.Sprintf("Internal error: %s", err),
+				}
+			}
 			defer c.controleProxy.Unsuspend()
 		}
 		res := cmd.f(c)

--- a/pftp/config.go
+++ b/pftp/config.go
@@ -18,6 +18,7 @@ type config struct {
 	ProxyTimeout    int         `toml:"proxy_timeout"`
 	TransferTimeout int         `toml:"transfer_timeout"`
 	MaxConnections  int32       `toml:"max_connections"`
+	ProxyProtocol   bool        `toml:"proxy_protocol"`
 	TLS             *tlsPair    `toml:"tls"`
 	TLSConfig       *tls.Config `toml:"-"`
 }
@@ -55,4 +56,5 @@ func defaultConfig(config *config) {
 	config.IdleTimeout = 900
 	config.ProxyTimeout = 900
 	config.TransferTimeout = 900
+	config.ProxyProtocol = false
 }

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -58,6 +58,7 @@ func NewProxyServer(timeout int, clientReader *bufio.Reader, clientWriter *bufio
 	return p, err
 }
 
+// TODO: DELETE
 func (s *ProxyServer) ReadFromOrigin() (string, error) {
 	if s.timeout > 0 {
 		s.origin.SetReadDeadline(time.Now().Add(time.Duration(time.Second.Nanoseconds() * int64(s.timeout))))
@@ -94,6 +95,7 @@ func (s *ProxyServer) SendToOrigin(line string) error {
 	return nil
 }
 
+// TODO: DELETE
 func (s *ProxyServer) SendToClient(line string) error {
 	s.log.debug("send to client:%s", line)
 	if _, err := s.clientWriter.Write([]byte(line)); err != nil {
@@ -226,6 +228,8 @@ func (s *ProxyServer) start(from *bufio.Reader, to *bufio.Writer) error {
 		if n, err := from.Read(buff); err != nil {
 			if err != io.EOF {
 				lastError = err
+			} else {
+
 			}
 			break
 		} else {

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -2,7 +2,7 @@ package pftp
 
 import (
 	"bufio"
-	"bytes"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -26,11 +26,11 @@ type ProxyServer struct {
 	originWriter *bufio.Writer
 	origin       net.Conn
 	doProxy      bool
-	pipe         chan []byte
 	CloseOk      bool
 	Switch       bool
 	mutex        *sync.Mutex
 	log          *logger
+	sem          int
 }
 
 func NewProxyServer(timeout int, clientReader *bufio.Reader, clientWriter *bufio.Writer, originAddr string, m *sync.Mutex, l *logger) (*ProxyServer, error) {
@@ -47,7 +47,6 @@ func NewProxyServer(timeout int, clientReader *bufio.Reader, clientWriter *bufio
 		origin:       c,
 		timeout:      timeout,
 		doProxy:      true,
-		pipe:         make(chan []byte, BUFFER_SIZE),
 		mutex:        m,
 		log:          l,
 	}
@@ -67,8 +66,6 @@ func (s *ProxyServer) ReadFromOrigin() (string, error) {
 	var reader *bufio.Reader
 	if s.doProxy {
 		reader = bufio.NewReader(s.origin)
-	} else {
-		reader = bufio.NewReader(bytes.NewBuffer(<-s.pipe))
 	}
 
 	for {
@@ -83,15 +80,28 @@ func (s *ProxyServer) ReadFromOrigin() (string, error) {
 }
 
 func (s *ProxyServer) SendToOrigin(line string) error {
+	cnt := 0
 	if s.timeout > 0 {
 		s.origin.SetReadDeadline(time.Now().Add(time.Duration(time.Second.Nanoseconds() * int64(s.timeout))))
 	}
 
-	s.log.debug("send to origin:%s", line)
-	if _, err := s.origin.Write([]byte(line)); err != nil {
-		return err
-	}
+	for {
+		if cnt > s.timeout {
+			return errors.New("Could not get semaphore to send to client")
+		}
 
+		s.log.debug("send to origin:%s", line)
+
+		if s.sem < 1 {
+			if _, err := s.origin.Write([]byte(line)); err != nil {
+				return err
+			}
+			s.sem++
+			break
+		}
+		time.Sleep(1 * time.Second)
+		cnt++
+	}
 	return nil
 }
 
@@ -118,9 +128,22 @@ func (s *ProxyServer) DownloadProxy() error {
 	return s.start(s.originReader, s.clientWriter)
 }
 
-func (s *ProxyServer) Suspend() {
+func (s *ProxyServer) Suspend() error {
 	s.log.debug("suspend proxy")
-	s.doProxy = false
+	cnt := 0
+	for {
+		if cnt > s.timeout {
+			return errors.New("Could not get semaphore to send to client")
+		}
+
+		if s.sem < 1 {
+			s.doProxy = false
+			break
+		}
+		time.Sleep(1 * time.Second)
+		cnt++
+	}
+	return nil
 }
 
 func (s *ProxyServer) Unsuspend() {
@@ -137,7 +160,10 @@ func (s *ProxyServer) SwitchOrigin(clientAddr string, originAddr string, proxyPr
 	s.log.debug("switch origin to: %s", originAddr)
 
 	if s.doProxy {
-		s.Suspend()
+		err := s.Suspend()
+		if err != nil {
+			return err
+		}
 		defer s.Unsuspend()
 	}
 
@@ -201,24 +227,20 @@ func (s *ProxyServer) start(from *bufio.Reader, to *bufio.Writer) error {
 					break loop
 				}
 
-				if s.doProxy {
-					s.mutex.Lock()
-					_, err := to.Write(b)
-					if err != nil {
-						lastError = err
-						s.mutex.Unlock()
-						break loop
-					}
-
-					if err := to.Flush(); err != nil {
-						lastError = err
-						s.mutex.Unlock()
-						break loop
-					}
+				s.mutex.Lock()
+				_, err := to.Write(b)
+				if err != nil {
+					lastError = err
 					s.mutex.Unlock()
-				} else {
-					s.pipe <- b
+					break loop
 				}
+
+				if err := to.Flush(); err != nil {
+					lastError = err
+					s.mutex.Unlock()
+					break loop
+				}
+				s.mutex.Unlock()
 			}
 		}
 		done <- struct{}{}
@@ -228,15 +250,20 @@ func (s *ProxyServer) start(from *bufio.Reader, to *bufio.Writer) error {
 		if n, err := from.Read(buff); err != nil {
 			if err != io.EOF {
 				lastError = err
-			} else {
-
 			}
 			break
 		} else {
 			if s.timeout > 0 {
 				s.origin.SetReadDeadline(time.Now().Add(time.Duration(time.Second.Nanoseconds() * int64(s.timeout))))
 			}
-			read <- buff[:n]
+
+			if s.doProxy || s.sem > 0 {
+				read <- buff[:n]
+			}
+
+			if s.sem > 0 {
+				s.sem--
+			}
 		}
 	}
 	close(read)


### PR DESCRIPTION
This PR make pftp server can use proxy protocol.

If use proxy protocol, pftp will send client ip and port to backend by proxy protocol header.

in config.toml
```
...
proxy_protocol = true / false (default : false)
...
```
For use proxy protocol, the backend server must have proxy protocol enabled.
(If not, login to backend will failed)
