### PR TITLE
receive proxy protocol from LoadBalancer or others

### DIFF
--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -274,20 +274,17 @@ func (c *clientHandler) parseLine(line string) {
 	}
 }
 
-func (c *clientHandler) getSourceIPFromProxyHeader(line string) error {
+func getSourceIPFromProxyHeader(line string) (string, error) {
 	params := strings.SplitN(strings.Trim(line, "\r\n"), " ", 6)
 	if len(params) != 6 {
-		return errors.New("wrong proxy header parameters")
+		return "", errors.New("wrong proxy header parameters")
 	}
 
-	sourceIP := params[2]
-	if net.ParseIP(sourceIP) == nil {
-		return errors.New("wrong ip address")
+	if net.ParseIP(params[2]) == nil || net.ParseIP(params[3]) == nil {
+		return "", errors.New("wrong source ip address")
 	}
 
-	sourcePort := params[4]
+	sourceip := params[2] + ":" + params[4]
 
-	c.sourceIP = sourceIP + ":" + sourcePort
-
-	return nil
+	return sourceip, nil
 }

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -81,12 +81,16 @@ func (c *clientHandler) handleTransfer() *result {
 }
 
 func (c *clientHandler) handleProxyHeader() *result {
-	if err := c.getSourceIPFromProxyHeader(c.line); err != nil {
+	sourceAddr, err := getSourceIPFromProxyHeader(c.line)
+	if err != nil {
 		return &result{
 			code: 500,
-			msg:  fmt.Sprintf("Proxy header parse error: %s", err),
+			msg:  fmt.Sprintf("Proxy header parse error"),
+			err:  err,
 		}
 	}
+
+	c.sourceIP = sourceAddr
 
 	return nil
 }

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -79,3 +79,14 @@ func (c *clientHandler) handleTransfer() *result {
 	}
 	return nil
 }
+
+func (c *clientHandler) handleProxyHeader() *result {
+	if err := c.getSourceIPFromProxyHeader(c.line); err != nil {
+		return &result{
+			code: 500,
+			msg:  fmt.Sprintf("Proxy header parse error: %s", err),
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR allows pftp to handle proxy protocols.

The source IP of the proxy protocol received from the LB, will be assigned to the sourceAddress for proxy protocol data to origin.