### PR TITLE
Add Protection handling commands

### DIFF
--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -24,6 +24,8 @@ func init() {
 	handlers["PROXY"] = &handleFunc{(*clientHandler).handleProxyHeader, false}
 	handlers["USER"] = &handleFunc{(*clientHandler).handleUSER, true}
 	handlers["AUTH"] = &handleFunc{(*clientHandler).handleAUTH, true}
+	handlers["PBSZ"] = &handleFunc{(*clientHandler).handlePBSZ, true}
+	handlers["PROT"] = &handleFunc{(*clientHandler).handlePROT, true}
 	handlers["RETR"] = &handleFunc{(*clientHandler).handleTransfer, false}
 	handlers["STOR"] = &handleFunc{(*clientHandler).handleTransfer, false}
 }

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -69,6 +69,70 @@ func (c *clientHandler) handleAUTH() *result {
 	}
 }
 
+func (c *clientHandler) handlePBSZ() *result {
+	if c.config.TLSConfig != nil {
+		var r *result
+		if c.param == "0" {
+			r = &result{
+				code: 200,
+				msg:  "PBSZ 0 successful",
+			}
+		} else {
+			r = &result{
+				code: 200,
+				msg:  "PBSZ=0",
+			}
+		}
+
+		if err := r.Response(c); err != nil {
+			return &result{
+				code: 550,
+				msg:  fmt.Sprint("Client Response Error"),
+				err:  err,
+				log:  c.log,
+			}
+		}
+
+		return nil
+	}
+	return &result{
+		code: 503,
+		msg:  fmt.Sprint("Not using TLS connection"),
+	}
+}
+
+func (c *clientHandler) handlePROT() *result {
+	if c.config.TLSConfig != nil {
+		var r *result
+		if c.param == "C" {
+			r = &result{
+				code: 200,
+				msg:  "Protection Set to Clear",
+			}
+		} else {
+			r = &result{
+				code: 431,
+				msg:  "Protection Set to Clear. Only Clear Protection supported",
+			}
+		}
+
+		if err := r.Response(c); err != nil {
+			return &result{
+				code: 550,
+				msg:  fmt.Sprint("Client Response Error"),
+				err:  err,
+				log:  c.log,
+			}
+		}
+
+		return nil
+	}
+	return &result{
+		code: 503,
+		msg:  fmt.Sprint("Not using TLS connection"),
+	}
+}
+
 func (c *clientHandler) handleTransfer() *result {
 	if c.config.TransferTimeout > 0 {
 		c.setClientDeadLine(c.config.TransferTimeout)

--- a/pftp/handle_commands_test.go
+++ b/pftp/handle_commands_test.go
@@ -38,6 +38,70 @@ func Test_clientHandler_handleAUTH(t *testing.T) {
 	}
 }
 
+func Test_clientHandler_handlePBSZ(t *testing.T) {
+	type fields struct {
+		config *config
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *result
+	}{
+		{
+			name: "none_tls",
+			fields: fields{
+				config: &config{},
+			},
+			want: &result{
+				code: 503,
+				msg:  "Not using TLS connection",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &clientHandler{
+				config: tt.fields.config,
+			}
+			if got := c.handlePBSZ(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("clientHandler.handlePBSZ() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_clientHandler_handlePROT(t *testing.T) {
+	type fields struct {
+		config *config
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *result
+	}{
+		{
+			name: "none_tls",
+			fields: fields{
+				config: &config{},
+			},
+			want: &result{
+				code: 503,
+				msg:  "Not using TLS connection",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &clientHandler{
+				config: tt.fields.config,
+			}
+			if got := c.handlePROT(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("clientHandler.handlePROT() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_clientHandler_handleUSER(t *testing.T) {
 	c, err := net.Dial("tcp", "127.0.0.1:21")
 	if err != nil {


### PR DESCRIPTION
### Overview
pftp throw these commands to destination ftp server because current pftp cannot process PBSZ, PROT commands.

However, ftp server can not understand that commands because ftp server did not get AUTH command before.(AUTH command processing by pftp server side)
So sometimes ftps connection will fail with some ftp console if using Explicit FTPS connection only.

This PR makes process PBSZ and PROT command by pftp side.

### Test
- before
```
...
<--- 230 User hungry.jp-heat1024 logged in.
---> PWD
<--- 257 "/" is the current directory
---> PBSZ 0
<--- 500 PBSZ not understood
---> PROT P
<--- 500 PROT not understood
---> PASV
...
```

- after
```
...
<--- 257 "/" is the current directory
---> PBSZ 0
<--- 200 PBSZ 0 successful
---> PROT P
<--- 431 Protection Set to Clear. Only Clear Protection supported
---> PASV
...
```

### about PROT
pftp makes data connection between client and origin server directly.
So, if pftp accept PROT level to Private, origin ftp server does not understand encrypted data packets.

This is the reason about only Clear level supported only.