### PR TITLE
Fix bug about response write to client. And now all connection segments can setted by TLS

### DIFF
--- a/Dockerfile-proftpd
+++ b/Dockerfile-proftpd
@@ -3,6 +3,9 @@ FROM bluefoxicy/proftpd
 ENV PROFTPD_PASSIVE_PORTS="21100-21110"
 ENV PROFTPD_AUTH_ORDER="mod_auth_pam.c* mod_auth_unix.c"
 ENV PROFTPD_DEFAULT_ROOT="/home/prouser"
+ENV PROFTPD_TLS="on"
+ENV PROFTPD_TLS_REQUIRED="off"
+
 
 VOLUME ["/home/prouser"]
 

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,11 @@ vsftpd-cleanup:
 proftpd: proftpd-cleanup
 	docker build -t proftpd-server:test -f Dockerfile-proftpd ./
 	docker run -d -v "`pwd`/misc/test/data/prouser":/home/prouser \
+	-v "`pwd`/tls/server.crt":/etc/ssl/certs/proftpd.crt \
+	-v "`pwd`/tls/server.key":/etc/ssl/private/proftpd.key \
+	-v "`pwd`/tls/server.crt":/etc/ssl/certs/chain.crt \
 	-p 20-21:20-21 -p 21100-21110:21100-21110 \
 	--name proftpd --restart=always proftpd-server:test
-
 proftpd-cleanup:
 	docker rm -f proftpd | true
 

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ proxy_protocol = false
 [tls]
 cert = "./tls/server.crt"
 key = "./tls/server.key"
+# make sure TLS protocol range allowed in origin ftp server (if only one protocol support, set min and max to same)
+min_protocol = "TLSv1"
+max_protocol = "TLSv1"
 
 [webapiserver]
 # %s replace by username on running

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/admpub/log v0.0.0-20180816172912-46327774dd0c
 	github.com/admpub/queueChan v0.0.0-20151001074356-79908f7a499f // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
-	github.com/golang/lint v0.0.0-20180702182130-06c8688daad7 // indirect
+	github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7 h1:2hRPrmiwPrp3fQX967rNJIhQPtiGXdlQWAxKbKw3VHA=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
+github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3 h1:I4BOK3PBMjhWfQM2zPJKK7lOBGsrsvOB7kBELP33hiE=
+github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/integration_test.go
+++ b/integration_test.go
@@ -131,14 +131,15 @@ func TestAuth(t *testing.T) {
 			client.Debug = true
 			client.TLSConfig.InsecureSkipVerify = true
 
-			err := client.Connect("localhost", 2121)
-			if err != nil {
-				return fmt.Errorf("integration.TestAuth() error = %v, wantErr %v", err, nil)
+			if err := client.Connect("localhost", 2121); err != nil {
+				return fmt.Errorf("integration.TestAuth() error = %v, want %v", err, "234 AUTH command ok")
 			}
 
-			// If Login failed with vsftpd user, Return Error
-			if err = client.Login(testset[index].User.ID, testset[index].User.Pass); err == nil {
+			// If Login success with vsftpd user(vsuser), Return Error
+			if err := client.Login(testset[index].User.ID, testset[index].User.Pass); err == nil && testset[index].User.ID == "vsuser" {
 				return fmt.Errorf("integration.TestAuth() error = %v, wantErr %v", err, errors.New("550 Permission denied"))
+			} else if err != nil && testset[index].User.ID == "prouser" {
+				return fmt.Errorf("integration.TestAuth() error = %v, want %s", err, "230 User prouser logged in")
 			}
 
 			return nil

--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -47,7 +47,7 @@ type clientHandler struct {
 	log                 *logger
 	deadline            time.Time
 	srcIP               string
-	isTLS               bool
+	tlsProtocol         uint16
 	isLoggedin          bool
 	previousTLSCommands []string
 }
@@ -65,7 +65,7 @@ func newClientHandler(connection net.Conn, c *config, m middleware, id int, curr
 		mutex:             &sync.Mutex{},
 		log:               &logger{fromip: connection.RemoteAddr().String(), id: id},
 		srcIP:             connection.RemoteAddr().String(),
-		isTLS:             false,
+		tlsProtocol:       0,
 		isLoggedin:        false,
 	}
 
@@ -247,7 +247,7 @@ func (c *clientHandler) handleCommand(line string) (r *result) {
 
 func (c *clientHandler) connectProxy() error {
 	if c.proxy != nil {
-		err := c.proxy.switchOrigin(c.srcIP, c.context.RemoteAddr, c.isTLS, c.previousTLSCommands)
+		err := c.proxy.switchOrigin(c.srcIP, c.context.RemoteAddr, c.tlsProtocol, c.previousTLSCommands)
 		if err != nil {
 			return err
 		}

--- a/pftp/config.go
+++ b/pftp/config.go
@@ -37,11 +37,15 @@ func loadConfig(path string) (*config, error) {
 		return nil, err
 	}
 
+	/* TLS version set to TLSv1 forcebly because     *
+	 * client/pftp/origin must set same TLS version. */
 	if c.TLS != nil {
 		if cert, err := tls.LoadX509KeyPair(c.TLS.Cert, c.TLS.Key); err == nil {
 			c.TLSConfig = &tls.Config{
 				NextProtos:   []string{"ftp"},
 				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS10,
+				MaxVersion:   tls.VersionTLS10,
 			}
 		} else {
 			return nil, err

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -34,10 +34,10 @@ func (c *clientHandler) handleUSER() *result {
 }
 
 func (c *clientHandler) handleAUTH() *result {
-	if c.config.TLSConfig != nil && c.param == "TLS" {
+	if c.config.TLSConfig != nil {
 		r := &result{
 			code: 234,
-			msg:  "AUTH command ok. Expecting TLS Negotiation.",
+			msg:  fmt.Sprintf("AUTH command ok. Expecting %s Negotiation.", c.param),
 		}
 
 		if err := r.Response(c); err != nil {
@@ -64,6 +64,7 @@ func (c *clientHandler) handleAUTH() *result {
 		*c.reader = *(bufio.NewReader(c.conn))
 		*c.writer = *(bufio.NewWriter(c.conn))
 		c.isTLS = true
+		c.previousTLSCommands = append(c.previousTLSCommands, c.line)
 
 		return nil
 	}

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -168,14 +168,14 @@ func (s *proxyServer) sendProxyHeader(clientAddr string, originAddr string) erro
 	return err
 }
 
-/* send command before login to origin.          *
-*  TLS version set to TLSv1 forcebly because     *
-*  client/pftp/origin must set same TLS version. */
-func (s *proxyServer) sendTLSCommand(previousTLSCommands []string) error {
+/* send command before login to origin.                  *
+*  TLS version set by client to pftp tls version         *
+*  because client/pftp/origin must set same TLS version. */
+func (s *proxyServer) sendTLSCommand(tlsProtocol uint16, previousTLSCommands []string) error {
 	config := tls.Config{
 		InsecureSkipVerify: true,
-		MinVersion:         tls.VersionTLS10,
-		MaxVersion:         tls.VersionTLS10,
+		MinVersion:         tlsProtocol,
+		MaxVersion:         tlsProtocol,
 	}
 
 	for _, cmd := range previousTLSCommands {
@@ -200,7 +200,7 @@ func (s *proxyServer) sendTLSCommand(previousTLSCommands []string) error {
 	return nil
 }
 
-func (s *proxyServer) switchOrigin(clientAddr string, originAddr string, useTLS bool, previousTLSCommands []string) error {
+func (s *proxyServer) switchOrigin(clientAddr string, originAddr string, tlsProtocol uint16, previousTLSCommands []string) error {
 	s.log.debug("switch origin to: %s", originAddr)
 
 	if s.passThrough {
@@ -241,7 +241,7 @@ func (s *proxyServer) switchOrigin(clientAddr string, originAddr string, useTLS 
 	old.Close()
 
 	// If client connect with TLS connection, make TLS connection to origin ftp server too.
-	if err := s.sendTLSCommand(previousTLSCommands); err != nil {
+	if err := s.sendTLSCommand(tlsProtocol, previousTLSCommands); err != nil {
 		return err
 	}
 

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -246,9 +246,9 @@ func (s *proxyServer) switchOrigin(clientAddr string, originAddr string, useTLS 
 	/* If client send PBSZ and PROT commands before login,  *
 	*  send stored command line to origin for set same PBSZ *
 	*  and PROT options                                     */
-	for i := 1; i < len(previousTLSCommands); i++ {
-		s.log.debug("send to origin: %s", previousTLSCommands[1])
-		if _, err := s.origin.Write([]byte(previousTLSCommands[1])); err != nil {
+	for i := 0; i < len(previousTLSCommands); i++ {
+		s.log.debug("send to origin: %s", previousTLSCommands[i])
+		if _, err := s.origin.Write([]byte(previousTLSCommands[i])); err != nil {
 			return err
 		}
 

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -287,6 +287,7 @@ func (s *proxyServer) start(from *bufio.Reader, to *bufio.Writer) error {
 							s.semUnlock()
 						}
 					}
+					<-send
 
 					lastError = err
 					s.stopChan <- struct{}{}


### PR DESCRIPTION
## Bug fix
- Previous version has mutex bug about get response from origin and write it to client.
- This bus appear often(but didn't appear must) when origin send response by multi-lined.

### Overview
<details>

<summary>In right operation</summary>

```
DEBU[0407] [3] addr:127.0.0.1:54006 read from client: FEAT

DEBU[0407] [3] addr:127.0.0.1:54006 send to origin: FEAT

DEBU[0407] [3] addr:127.0.0.1:54006 write to client:
211-Features:
 LANG en-US*
 EPRT
 SITE SYMLINK
 EPSV
 SITE UTIME
 MDTM
 SITE RMDIR
 TVFS
 SITE COPY
 MFMT
 SIZE
 SITE MKDIR
 MFF modify;UNIX.group;UNIX.mode;
 REST STREAM
 MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.mode*;UNIX.owner*;
 UTF8
211 End
, 279Byte
```

</details>

<details>

<summary>when bug appear</summary>

```
DEBU[0011] [1] addr:127.0.0.1:54170 read from client: FEAT

DEBU[0011] [1] addr:127.0.0.1:54170 send to origin: FEAT

DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:    # First got response message is '211-Features'
211-Features:
, 15Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:   # Got second response before write first message to client. read buffer has overwrited
 AUTH TLS
, 11Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:    # Send response from origin to client. but it's not first received message. It's second received message and first received message's length
 AUTH TLS
s:
, 15Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
 CCC
TLS
, 11Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 CCC
TLS
s:
set to Private
ged in.
1024
, 6Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 CLNT
LS
s:
set to Private
ged in.
1024
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
, 6Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
 EPRT
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 EPRT
LS
s:
set to Private
ged in.
1024
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 EPSV
LS
s:
set to Private
ged in.
1024
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
 EPSV
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 HOST
LS
s:
set to Private
ged in.
1024
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
 HOST
, 7Byte
DEBU[0011] [1] addr:127.0.0.1:54170 response from origin:
 LANG it-IT;bg-BG;ja-JP;en-US;ru-RU;fr-FR;zh-CN;ko-KR;es-ES;zh-TW
, 67Byte
DEBU[0011] [1] addr:127.0.0.1:54170 write to client:
 LANG i, 7Byte
...
```

</details>

When bug situation, the first received `211-Features:` has disappear and not send to client.

It might be the reason about `short response` error or get looped in ABOR commands sometimes.

### Make mutex
- Add chan between read from origin and write to client.
- Now, pftp must handle response message in one by one line and never miss messages.
- When client send QUIT and origin response 221, pftp send 221 to client before make stop channel.
(It makes client disconnect clearly)

<details>

<summary>Debug log after fix bug</summary>

```
...
DEBU[0005] [1] addr:127.0.0.1:53053 read from client: FEAT

DEBU[0005] [1] addr:127.0.0.1:53053 send to origin: FEAT

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin: 211-Features:

DEBU[0005] [1] addr:127.0.0.1:53053 write to client: 211-Features:

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  AUTH TLS

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  AUTH TLS

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  CCC

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  CCC

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  CLNT

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  CLNT

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  EPRT

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  EPRT

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  EPSV

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  EPSV

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  HOST

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  HOST

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  LANG it-IT;bg-BG;ja-JP;en-US;ru-RU;fr-FR;zh-CN;ko-KR;es-ES;zh-TW

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  LANG it-IT;bg-BG;ja-JP;en-US;ru-RU;fr-FR;zh-CN;ko-KR;es-ES;zh-TW

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  MDTM

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  MDTM

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  MFF modify;UNIX.group;UNIX.mode;

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  MFF modify;UNIX.group;UNIX.mode;

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  MFMT

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  MFMT

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*;

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*;

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  PBSZ

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  PBSZ

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  PROT

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  PROT

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  REST STREAM

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  REST STREAM

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  SIZE

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  SIZE

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  SSCN

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  SSCN

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  TVFS

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  TVFS

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin:  UTF8

DEBU[0005] [1] addr:127.0.0.1:53053 write to client:  UTF8

DEBU[0005] [1] addr:127.0.0.1:53053 response from origin: 211 End

DEBU[0005] [1] addr:127.0.0.1:53053 write to client: 211 End
...
```

</details>

## Make TLS connection about all N/W segments
In previous PR, I made PBSZ and PROT commands handle simple response.
But some FTP client can not set PROT level to Clear. The other FTP client send PBSZ and PROT before USER login.
It makes problem because if user not login, pftp doesn't know where is real origin ftp server. So can not set backend TLS connection exactly same with frontend segment. So, now pftp store PBSZ and PROT commands if USER not login.
When user login and switch origin to real ftp server, pftp send AUTH command and stored PBSZ and PROT commands to origin for make same connection with client to pftp TLS connection.
Of course, if user login before send PBSZ and PROT commands, pftp only send AUTH command to origin(in this case, PBSZ and PROT commands will passthrough to origin server)

