### PR TITLE
increase current connection counter after complate established to origin

### DIFF
--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -127,9 +127,6 @@ func (c *clientHandler) handleCommands() error {
 		}
 	}
 
-	// increase current connection
-	atomic.AddInt32(c.currentConnection, 1)
-
 	// wait until all goroutine has done
 	pError := <-proxyError
 	cError := <-clientError
@@ -301,15 +298,16 @@ func (c *clientHandler) connectProxy() error {
 	} else {
 		p, err := newProxyServer(
 			&proxyServerConfig{
-				timeout:       c.config.ProxyTimeout,
-				clientReader:  c.reader,
-				clientWriter:  c.writer,
-				originAddr:    c.context.RemoteAddr,
-				mutex:         c.mutex,
-				log:           c.log,
-				proxyProtocol: c.config.ProxyProtocol,
-				welcomeMsg:    c.config.WelcomeMsg,
-				established:   c.chkEstablished,
+				timeout:           c.config.ProxyTimeout,
+				clientReader:      c.reader,
+				clientWriter:      c.writer,
+				originAddr:        c.context.RemoteAddr,
+				currentConnection: c.currentConnection,
+				mutex:             c.mutex,
+				log:               c.log,
+				proxyProtocol:     c.config.ProxyProtocol,
+				welcomeMsg:        c.config.WelcomeMsg,
+				established:       c.chkEstablished,
 			})
 
 		if err != nil {

--- a/pftp/client_handler.go
+++ b/pftp/client_handler.go
@@ -77,7 +77,9 @@ func newClientHandler(connection net.Conn, c *config, m middleware, id int, curr
 
 func (c *clientHandler) end() {
 	c.conn.Close()
-	atomic.AddInt32(c.currentConnection, -1)
+	if c.isLoggedin {
+		atomic.AddInt32(c.currentConnection, -1)
+	}
 }
 
 func (c *clientHandler) setClientDeadLine(t int) {
@@ -298,16 +300,15 @@ func (c *clientHandler) connectProxy() error {
 	} else {
 		p, err := newProxyServer(
 			&proxyServerConfig{
-				timeout:           c.config.ProxyTimeout,
-				clientReader:      c.reader,
-				clientWriter:      c.writer,
-				originAddr:        c.context.RemoteAddr,
-				currentConnection: c.currentConnection,
-				mutex:             c.mutex,
-				log:               c.log,
-				proxyProtocol:     c.config.ProxyProtocol,
-				welcomeMsg:        c.config.WelcomeMsg,
-				established:       c.chkEstablished,
+				timeout:       c.config.ProxyTimeout,
+				clientReader:  c.reader,
+				clientWriter:  c.writer,
+				originAddr:    c.context.RemoteAddr,
+				mutex:         c.mutex,
+				log:           c.log,
+				proxyProtocol: c.config.ProxyProtocol,
+				welcomeMsg:    c.config.WelcomeMsg,
+				established:   c.chkEstablished,
 			})
 
 		if err != nil {

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"reflect"
 	"strings"
+	"sync/atomic"
 )
 
 func (c *clientHandler) handleUSER() *result {
@@ -29,6 +30,10 @@ func (c *clientHandler) handleUSER() *result {
 		}
 	}
 	c.isLoggedin = true
+
+	// increase current connection after send USER command for real login
+	atomic.AddInt32(c.currentConnection, 1)
+	c.log.info("current connection %d", atomic.LoadInt32(c.currentConnection))
 
 	return nil
 }

--- a/pftp/handle_commands.go
+++ b/pftp/handle_commands.go
@@ -33,7 +33,7 @@ func (c *clientHandler) handleUSER() *result {
 
 	// increase current connection after send USER command for real login
 	atomic.AddInt32(c.currentConnection, 1)
-	c.log.info("current connection %d", atomic.LoadInt32(c.currentConnection))
+	c.log.debug("current connection count: %d", atomic.LoadInt32(c.currentConnection))
 
 	return nil
 }

--- a/pftp/handle_commands_test.go
+++ b/pftp/handle_commands_test.go
@@ -147,13 +147,15 @@ func Test_clientHandler_handleUSER(t *testing.T) {
 			},
 		},
 	}
+	var cn int32
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &clientHandler{
-				config:  tt.fields.config,
-				conn:    tt.fields.conn,
-				context: tt.fields.context,
-				log:     &logger{},
+				config:            tt.fields.config,
+				conn:              tt.fields.conn,
+				context:           tt.fields.context,
+				log:               &logger{},
+				currentConnection: &cn,
 			}
 			got := c.handleUSER()
 			if (got != nil && tt.want == nil) || (tt.want != nil && (got.code != tt.want.code || got.msg != tt.want.msg)) {

--- a/pftp/proxy.go
+++ b/pftp/proxy.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	proxyproto "github.com/pires/go-proxyproto"
@@ -21,39 +20,37 @@ const (
 )
 
 type proxyServer struct {
-	id                int
-	timeout           int
-	clientReader      *bufio.Reader
-	clientWriter      *bufio.Writer
-	originReader      *bufio.Reader
-	originWriter      *bufio.Writer
-	origin            net.Conn
-	currentConnection *int32
-	passThrough       bool
-	mutex             *sync.Mutex
-	log               *logger
-	proxyProtocol     bool
-	stopChan          chan struct{}
-	stopChanDone      chan struct{}
-	established       chan struct{}
-	stop              bool
-	secureCommands    []string
-	isSwitched        bool
-	welcomeMsg        string
+	id             int
+	timeout        int
+	clientReader   *bufio.Reader
+	clientWriter   *bufio.Writer
+	originReader   *bufio.Reader
+	originWriter   *bufio.Writer
+	origin         net.Conn
+	passThrough    bool
+	mutex          *sync.Mutex
+	log            *logger
+	proxyProtocol  bool
+	stopChan       chan struct{}
+	stopChanDone   chan struct{}
+	established    chan struct{}
+	stop           bool
+	secureCommands []string
+	isSwitched     bool
+	welcomeMsg     string
 }
 
 type proxyServerConfig struct {
-	timeout           int
-	clientReader      *bufio.Reader
-	clientWriter      *bufio.Writer
-	originAddr        string
-	currentConnection *int32
-	mutex             *sync.Mutex
-	log               *logger
-	proxyProtocol     bool
-	welcomeMsg        string
-	secureCommands    []string
-	established       chan struct{}
+	timeout        int
+	clientReader   *bufio.Reader
+	clientWriter   *bufio.Writer
+	originAddr     string
+	mutex          *sync.Mutex
+	log            *logger
+	proxyProtocol  bool
+	welcomeMsg     string
+	secureCommands []string
+	established    chan struct{}
 }
 
 func newProxyServer(conf *proxyServerConfig) (*proxyServer, error) {
@@ -63,23 +60,22 @@ func newProxyServer(conf *proxyServerConfig) (*proxyServer, error) {
 	}
 
 	p := &proxyServer{
-		clientReader:      conf.clientReader,
-		clientWriter:      conf.clientWriter,
-		originWriter:      bufio.NewWriter(c),
-		originReader:      bufio.NewReader(c),
-		currentConnection: conf.currentConnection,
-		origin:            c,
-		timeout:           conf.timeout,
-		passThrough:       true,
-		mutex:             conf.mutex,
-		log:               conf.log,
-		proxyProtocol:     conf.proxyProtocol,
-		stopChan:          make(chan struct{}),
-		stopChanDone:      make(chan struct{}),
-		welcomeMsg:        "220 " + conf.welcomeMsg + "\r\n",
-		secureCommands:    conf.secureCommands,
-		isSwitched:        false,
-		established:       conf.established,
+		clientReader:   conf.clientReader,
+		clientWriter:   conf.clientWriter,
+		originWriter:   bufio.NewWriter(c),
+		originReader:   bufio.NewReader(c),
+		origin:         c,
+		timeout:        conf.timeout,
+		passThrough:    true,
+		mutex:          conf.mutex,
+		log:            conf.log,
+		proxyProtocol:  conf.proxyProtocol,
+		stopChan:       make(chan struct{}),
+		stopChanDone:   make(chan struct{}),
+		welcomeMsg:     "220 " + conf.welcomeMsg + "\r\n",
+		secureCommands: conf.secureCommands,
+		isSwitched:     false,
+		established:    conf.established,
 	}
 	p.log.debug("new proxy from=%s to=%s", c.LocalAddr(), c.RemoteAddr())
 
@@ -281,10 +277,6 @@ func (s *proxyServer) start(from *bufio.Reader, to *bufio.Writer) error {
 				// response user setted welcome message
 				if strings.Compare(getCode(buff)[0], "220") == 0 && !s.isSwitched {
 					buff = s.welcomeMsg
-
-					// increase current connection after establishe complate
-					atomic.AddInt32(s.currentConnection, 1)
-					s.log.info("current connection %d", atomic.LoadInt32(s.currentConnection))
 
 					// send first response complate signal
 					if s.established != nil {


### PR DESCRIPTION
Some ftp check scripts just dial up for check 220 response from server, and does not send QUIT after connect. also they never login to server.
So if use that kind of check script, connection will exceed max client count soon.
It makes real client can not connect to server.


For solve this problem, this PR moves `client counter increase codes` to where after USER command process is completed.
