### PR TITLE
Add `ignore_transfer_host` to ignore data channel host

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,9 @@ data_listen_port_range = "65000-65100" # "min-max"(default : random)
 ## Set client(the default setup), use client's connected mode.
 transfer_mode = "pasv"  # PASV / Passive / PORT / Active / client (default : client)
 
+## Should we ignore the passive data channel IP sent by the origin FTP server ? (default: false)
+ignore_passive_ip = false
+
 ## Masquerade pftp's ip to setted IP(may be LB's IP).
 ## It might necessary if pftp server is at behind the LB.
 masquerade_ip = "127.0.0.1"

--- a/pftp/config.go
+++ b/pftp/config.go
@@ -32,6 +32,7 @@ type config struct {
 	DataPortRange   string      `toml:"data_listen_port_range"`
 	MasqueradeIP    string      `toml:"masquerade_ip"`
 	TransferMode    string      `toml:"transfer_mode"`
+	IgnorePassiveIP bool        `toml:"ignore_passive_ip"`
 	TLS             *tlsPair    `toml:"tls"`
 	TLSConfig       *tls.Config `toml:"-"`
 }
@@ -126,6 +127,7 @@ func defaultConfig(config *config) {
 	config.DataPortRange = ""
 	config.WelcomeMsg = "FTP proxy ready"
 	config.TransferMode = "CLIENT"
+	config.IgnorePassiveIP = false
 }
 
 func dataPortRangeValidation(r string) error {

--- a/pftp/data_handler.go
+++ b/pftp/data_handler.go
@@ -438,7 +438,7 @@ func (d *dataHandler) dataTransfer(reader net.Conn, writer net.Conn) error {
 	return lastErr
 }
 
-// parse port comand line
+// parse port comand line (active data conn)
 func (d *dataHandler) parsePORTcommand(line string) error {
 	// PORT command format : "PORT h1,h2,h3,h4,p1,p2\r\n"
 	var err error
@@ -453,7 +453,7 @@ func (d *dataHandler) parsePORTcommand(line string) error {
 	return err
 }
 
-// parse eprt comand line
+// parse eprt comand line (active data conn)
 func (d *dataHandler) parseEPRTcommand(line string) error {
 	// EPRT command format
 	// - IPv4 : "EPRT |1|h1.h2.h3.h4|port|\r\n"
@@ -470,7 +470,7 @@ func (d *dataHandler) parseEPRTcommand(line string) error {
 	return err
 }
 
-// parse pasv comand line
+// parse pasv comand line (passive data conn)
 func (d *dataHandler) parsePASVresponse(line string) error {
 	// PASV response format : "227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).\r\n"
 	var err error
@@ -485,14 +485,14 @@ func (d *dataHandler) parsePASVresponse(line string) error {
 	d.originConn.remoteIP, d.originConn.remotePort, err = parseLineToAddr(line[startIndex+1 : endIndex])
 
 	// if received ip is not public IP, ignore it
-	if !isPublicIP(net.ParseIP(d.originConn.remoteIP)) {
+	if !isPublicIP(net.ParseIP(d.originConn.remoteIP)) || d.config.IgnorePassiveIP {
 		d.originConn.remoteIP = d.originConn.originalRemoteIP
 	}
 
 	return err
 }
 
-// parse epsv comand line
+// parse epsv comand line (passive data conn)
 func (d *dataHandler) parseEPSVresponse(line string) error {
 	// EPSV response format : "229 Entering Extended Passive Mode (|||port|)\r\n"
 	startIndex := strings.Index(line, "(")

--- a/pftp/data_handler_test.go
+++ b/pftp/data_handler_test.go
@@ -301,7 +301,7 @@ func Test_dataHandler_parsePASVresponse(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "passive_mode_parse_ok",
+			name: "passive_mode_parse_ok_public",
 			fields: fields{
 				line:   "227 Entering Passive Mode (20,30,40,50,100,10).\r\n",
 				mode:   "PASV",
@@ -309,6 +309,36 @@ func Test_dataHandler_parsePASVresponse(t *testing.T) {
 			},
 			want: want{
 				ip:   "20.30.40.50",
+				port: "25610",
+				err:  "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "passive_mode_parse_ok_private",
+			fields: fields{
+				line:   "227 Entering Passive Mode (10,30,40,50,100,10).\r\n",
+				mode:   "PASV",
+				config: &config{},
+			},
+			want: want{
+				ip:   "",
+				port: "25610",
+				err:  "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "passive_mode_parse_ignore_public_passive_ip",
+			fields: fields{
+				line:   "227 Entering Passive Mode (20,30,40,50,100,10).\r\n",
+				mode:   "PASV",
+				config: &config{
+					IgnorePassiveIP: true,
+				},
+			},
+			want: want{
+				ip:   "",
 				port: "25610",
 				err:  "",
 			},

--- a/pftp/data_handler_test.go
+++ b/pftp/data_handler_test.go
@@ -303,12 +303,12 @@ func Test_dataHandler_parsePASVresponse(t *testing.T) {
 		{
 			name: "passive_mode_parse_ok",
 			fields: fields{
-				line:   "227 Entering Passive Mode (10,19,10,10,100,10).\r\n",
+				line:   "227 Entering Passive Mode (20,30,40,50,100,10).\r\n",
 				mode:   "PASV",
 				config: &config{},
 			},
 			want: want{
-				ip:   "10.10.10.10",
+				ip:   "20.30.40.50",
 				port: "25610",
 				err:  "",
 			},
@@ -342,8 +342,8 @@ func Test_dataHandler_parsePASVresponse(t *testing.T) {
 
 			got.ip = d.originConn.remoteIP
 			got.port = d.originConn.remotePort
-			if tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("dataHandler.parsePASVresponse() = %s, want %s", got.err, tt.want.err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("dataHandler.parsePASVresponse() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Hi,

Some servers (or setups) send misconfigured data channel hosts. We
add a way to bypass these hosts and thus use the original server IP.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>