### PR TITLE
Fix PORT/PASV/EPRT not enforcing tests

### DIFF
--- a/pftp/data_handler_test.go
+++ b/pftp/data_handler_test.go
@@ -108,8 +108,8 @@ func Test_dataHandler_parsePORTcommand(t *testing.T) {
 
 			got.ip = d.clientConn.remoteIP
 			got.port = d.clientConn.remotePort
-			if tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("dataHandler.parsePORTcommand() = %s, want %s", got.err, tt.want.err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("dataHandler.parsePORTresponse() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -232,8 +232,8 @@ func Test_dataHandler_parseEPRTcommand(t *testing.T) {
 
 			got.ip = d.clientConn.remoteIP
 			got.port = d.clientConn.remotePort
-			if tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("dataHandler.parseEPRTcommand() = %s, want %s", got.err, tt.want.err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("dataHandler.parseEPRTresponse() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -438,8 +438,8 @@ func Test_dataHandler_parseEPSV(t *testing.T) {
 
 			got.ip = d.originConn.remoteIP
 			got.port = d.originConn.remotePort
-			if tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("dataHandler.parseEPSVresponse() = %s, want %s", got.err, tt.want.err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("dataHandler.parseEPSVresponse() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Hi,

This small MR comes from #41 : I saw that we weren't enforcing struct comparison if we didn't want an error.

By fixing the logic, the tests now fail on some of them (ignoring port for private IPs).

I thus wonder, should the "private IP" logic only be applied for passive commands ? What was the logic to it ?

Thanks and cheers

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>