### PR TITLE
Passive: support IPv6 too

### DIFF
--- a/pftp/data_handler.go
+++ b/pftp/data_handler.go
@@ -162,8 +162,7 @@ func (d *dataHandler) setNewListener() (*net.TCPListener, error) {
 			return nil, err
 		}
 
-		// only can support IPv4 between origin server connection
-		if listener, err = net.ListenTCP("tcp4", lAddr); err != nil {
+		if listener, err = net.ListenTCP("tcp", lAddr); err != nil {
 			if counter > connectionTimeout {
 				d.log.err("cannot set listener")
 


### PR DESCRIPTION
Hi,
This small MR makes the data channel listen on v6 too. Since we already supported IPv6 (through EPSV, ..) we needed to listen on in v6 too. This makes the server effectively dual-stack

Cheers
Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>
