### PR TITLE
add NewFtpServerFromConfig()

### DIFF
--- a/pftp/config.go
+++ b/pftp/config.go
@@ -35,24 +35,24 @@ type config struct {
 	TLS             *tlsPair `toml:"tls"`
 }
 
-type tlsPair struct {
-	Cert        string `toml:"cert"`
-	Key         string `toml:"key"`
-	CACert      string `toml:"ca_cert"`
-	CipherSuite string `toml:"cipher_suite"`
-	MinProtocol string `toml:"min_protocol"`
-	MaxProtocol string `toml:"max_protocol"`
-}
+// NewConfig creates a new config instance and applies the provided options.
+// Validates the configuration and returns an error if validation fails.
+func NewConfig(opts ...ConfigOption) (config, error) {
+	cfg := config{}
+	defaultConfig(&cfg)
 
-func loadConfig(path string) (*config, error) {
-	var c config
-	defaultConfig(&c)
-
-	_, err := toml.DecodeFile(path, &c)
-	if err != nil {
-		return nil, err
+	for _, o := range opts {
+		o(&cfg)
 	}
 
+	if err := validateConfig(&cfg); err != nil {
+		return config{}, err
+	}
+
+	return cfg, nil
+}
+
+func validateConfig(c *config) error {
 	// validate Data listen port randg
 	if err := dataPortRangeValidation(c.DataPortRange); err != nil {
 		logrus.Debug(err)
@@ -61,7 +61,7 @@ func loadConfig(path string) (*config, error) {
 
 	// validate Masquerade IP
 	if (len(c.MasqueradeIP) > 0) && (net.ParseIP(c.MasqueradeIP)) == nil {
-		return nil, fmt.Errorf("configuration error: Masquerade IP is wrong")
+		return fmt.Errorf("configuration error: Masquerade IP is wrong")
 	}
 
 	// validate Transfer mode config
@@ -76,7 +76,44 @@ func loadConfig(path string) (*config, error) {
 	case "CLIENT":
 		break
 	default:
-		return nil, fmt.Errorf("configuration error: Transfer mode config is wrong")
+		return fmt.Errorf("configuration error: Transfer mode config is wrong")
+	}
+
+	return nil
+}
+
+type tlsPair struct {
+	Cert        string `toml:"cert"`
+	Key         string `toml:"key"`
+	CACert      string `toml:"ca_cert"`
+	CipherSuite string `toml:"cipher_suite"`
+	MinProtocol string `toml:"min_protocol"`
+	MaxProtocol string `toml:"max_protocol"`
+}
+
+// NewTLSConfig creates a new tlsPair instance and applies the provided options.
+// Returns the configured TLS settings.
+func NewTLSConfig(opts ...TLSConfigOption) tlsPair {
+	tls := tlsPair{}
+
+	for _, o := range opts {
+		o(&tls)
+	}
+
+	return tls
+}
+
+func loadConfig(path string) (*config, error) {
+	var c config
+	defaultConfig(&c)
+
+	_, err := toml.DecodeFile(path, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateConfig(&c); err != nil {
+		return nil, err
 	}
 
 	return &c, nil
@@ -123,4 +160,154 @@ func dataPortRangeValidation(r string) error {
 	}
 
 	return nil
+}
+
+type ConfigOption func(c *config)
+
+// WithListenAddr sets the listening address for the server.
+func WithListenAddr(addr string) ConfigOption {
+	return func(c *config) {
+		c.ListenAddr = addr
+	}
+}
+
+// WithRemoteAddr sets the remote address for the server.
+func WithRemoteAddr(addr string) ConfigOption {
+	return func(c *config) {
+		c.RemoteAddr = addr
+	}
+}
+
+// WithIdleTimeout sets the idle timeout for the server in seconds.
+func WithIdleTimeout(timeout int) ConfigOption {
+	return func(c *config) {
+		c.IdleTimeout = timeout
+	}
+}
+
+// WithProxyTimeout sets the timeout for the proxy connection in seconds.
+func WithProxyTimeout(timeout int) ConfigOption {
+	return func(c *config) {
+		c.ProxyTimeout = timeout
+	}
+}
+
+// WithTransferTimeout sets the timeout for data transfers in seconds.
+func WithTransferTimeout(timeout int) ConfigOption {
+	return func(c *config) {
+		c.TransferTimeout = timeout
+	}
+}
+
+// WithMaxConnections sets the maximum number of simultaneous connections.
+func WithMaxConnections(maxConn int32) ConfigOption {
+	return func(c *config) {
+		c.MaxConnections = maxConn
+	}
+}
+
+// WithProxyProtocol enables or disables the proxy protocol.
+func WithProxyProtocol(proxyProtocol bool) ConfigOption {
+	return func(c *config) {
+		c.ProxyProtocol = proxyProtocol
+	}
+}
+
+// WithWelcomeMessage sets the welcome message for the server.
+func WithWelcomeMessage(msg string) ConfigOption {
+	return func(c *config) {
+		c.WelcomeMsg = msg
+	}
+}
+
+// WithKeepaliveTime sets the keep-alive time for the server in seconds.
+func WithKeepaliveTime(keepalive int) ConfigOption {
+	return func(c *config) {
+		c.KeepaliveTime = keepalive
+	}
+}
+
+// WithDataChanProxy enables or disables data channel proxying.
+func WithDataChanProxy(dataChanProxy bool) ConfigOption {
+	return func(c *config) {
+		c.DataChanProxy = dataChanProxy
+	}
+}
+
+// WithDataPortRange sets the range of data ports available for the server.
+func WithDataPortRange(dataPortRange string) ConfigOption {
+	return func(c *config) {
+		c.DataPortRange = dataPortRange
+	}
+}
+
+// WithMasqueradeIP sets the IP address for masquerading connections.
+func WithMasqueradeIP(masqueradeIP string) ConfigOption {
+	return func(c *config) {
+		c.MasqueradeIP = masqueradeIP
+	}
+}
+
+// WithTransferMode sets the transfer mode for data transfers.
+func WithTransferMode(transferMode string) ConfigOption {
+	return func(c *config) {
+		c.TransferMode = transferMode
+	}
+}
+
+// WithIgnorePassiveIP enables or disables ignoring of the passive IP address.
+func WithIgnorePassiveIP(ignorePassiveIP bool) ConfigOption {
+	return func(c *config) {
+		c.IgnorePassiveIP = ignorePassiveIP
+	}
+}
+
+// WithTLSConfig sets the TLS configuration for the server.
+func WithTLSConfig(tls *tlsPair) ConfigOption {
+	return func(c *config) {
+		c.TLS = tls
+	}
+}
+
+type TLSConfigOption func(t *tlsPair)
+
+// WithCertificate sets the certificate file for TLS configuration.
+func WithCertificate(cert string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.Cert = cert
+	}
+}
+
+// WithKey sets the key file for TLS configuration.
+func WithKey(key string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.Key = key
+	}
+}
+
+// WithCACert sets the CA certificate file for TLS configuration.
+func WithCACert(ca string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.CACert = ca
+	}
+}
+
+func WithCipherSuite(cs string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.CipherSuite = cs
+	}
+}
+
+// WithMinProtocol sets the minimum protocol version for TLS configuration.
+func WithMinProtocol(minProtocol string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.MinProtocol = minProtocol
+	}
+}
+
+// WithMaxProtocol sets the maximum protocol version for TLS configuration.
+func WithMaxProtocol(maxProtocol string) TLSConfigOption {
+	return func(t *tlsPair) {
+		t.MaxProtocol = maxProtocol
+	}
 }

--- a/pftp/server.go
+++ b/pftp/server.go
@@ -34,6 +34,11 @@ func NewFtpServer(confFile string) (*FtpServer, error) {
 		return nil, err
 	}
 
+	return NewFtpServerFromConfig(c)
+}
+
+// NewFtpServerFromConfig creates new ftp server from the given config
+func NewFtpServerFromConfig(c *config) (*FtpServer, error) {
 	m := middleware{}
 	server := &FtpServer{
 		config:     c,
@@ -43,10 +48,11 @@ func NewFtpServer(confFile string) (*FtpServer, error) {
 	// build and set TLS configuration
 	if server.config.TLS != nil {
 		logrus.Info("build server TLS configurations...")
-		server.serverTLSData, err = buildTLSConfigForClient(server.config.TLS)
+		serverTLSData, err := buildTLSConfigForClient(server.config.TLS)
 		if err != nil {
 			return nil, err
 		}
+		server.serverTLSData = serverTLSData
 		logrus.Infof("TLS certificate successfully loaded")
 	}
 


### PR DESCRIPTION
ファイル以外からもサーバを初期化できるようにしました。
validationやmutationを必ず経由させるように、構造体自体は非公開のままにしてあります。 ユーザは必ずNewConfig()を利用してconfigを初期化します。これまでのファイルを利用したサーバの初期化は挙動が変わらないようになっているはずです。

変更内容は以下のとおりです。

- これまで `loadConfig()` で行っていたバリデーションを `validateConfig()` に移しました。
  - これは `loadConfig()` からも `NewConfig()` からも呼び出されるので、既存の実装に影響はありません
- `NewConfig()` および `NewTLSConfig()` を定義し、ユーザが間接的に config構造体を設定できるようにしました
- `NewFtpServerFromConfig()` を追加しました